### PR TITLE
mainboard/pcengines/apu2/bootorder_def: add space character in last e…

### DIFF
--- a/src/mainboard/pcengines/apu2/bootorder_def
+++ b/src/mainboard/pcengines/apu2/bootorder_def
@@ -6,4 +6,4 @@
 /pci@i0cf8/*@11/drive@0/disk@0
 /pci@i0cf8/*@11/drive@1/disk@0
 /rom@genroms/pxe.rom
-
+ 


### PR DESCRIPTION
…ntry to prevent sortbootorder from printing unnecessary EOL characters