### PR TITLE
mainboard/pcengines/apu2/bootorder_def,bootorder_map: remove last emp…

### DIFF
--- a/src/mainboard/pcengines/apu2/bootorder_def
+++ b/src/mainboard/pcengines/apu2/bootorder_def
@@ -6,4 +6,3 @@
 /pci@i0cf8/*@11/drive@0/disk@0
 /pci@i0cf8/*@11/drive@1/disk@0
 /rom@genroms/pxe.rom
-

--- a/src/mainboard/pcengines/apu2/bootorder_map
+++ b/src/mainboard/pcengines/apu2/bootorder_map
@@ -6,4 +6,3 @@ e SDCARD
 f mSATA
 g SATA
 h iPXE
-


### PR DESCRIPTION
…ty line so that sortbootorder doesn't print unnecessary EOL characters