### PR TITLE
Memtest86+: revert CB_NOPSD changes and switch to mainline

### DIFF
--- a/payloads/Kconfig
+++ b/payloads/Kconfig
@@ -106,15 +106,6 @@ config MEMTEST_MASTER
 	  non-reproducible, as it can fetch different code each time.
 endchoice
 
-config MEMTEST_DISABLE_SPD
-	bool "Disable retrieving SPD info"
-	depends on MEMTEST_SECONDARY_PAYLOAD
-	help
-	  Disables retrieving RAM SPD info in Memtest86+.
-
-	  Some chipsets and mainboards do not support this feature and it
-	  should be disabled in Memtest86+ to avoid unwanted behaviour.
-
 config NVRAMCUI_SECONDARY_PAYLOAD
 	bool "Load nvramcui as a secondary payload"
 	default n

--- a/payloads/external/Makefile.inc
+++ b/payloads/external/Makefile.inc
@@ -206,10 +206,6 @@ ifeq ($(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO),yy)
 		SERIAL_BAUD_RATE=$(CONFIG_TTYS0_BAUD)
 endif
 
-ifeq ($(CONFIG_MEMTEST_DISABLE_SPD),y)
-	MEMTEST_SPD_OPTIONS=CB_NOSPD=1
-endif
-
 payloads/external/Memtest86Plus/memtest86plus/memtest: $(DOTCONFIG)
 	$(MAKE) -C payloads/external/Memtest86Plus all \
 		CC="$(CC_x86_32)" \
@@ -218,8 +214,6 @@ payloads/external/Memtest86Plus/memtest86plus/memtest: $(DOTCONFIG)
 		AS="$(AS_x86_32)" \
 		CONFIG_MEMTEST_MASTER=$(CONFIG_MEMTEST_MASTER) \
 		CONFIG_MEMTEST_STABLE=$(CONFIG_MEMTEST_STABLE) \
-		CONFIG_MEMTEST_SPD=$(CONFIG_MEMTEST_SPD) \
-		$(MEMTEST_SPD_OPTIONS) \
 		$(MEMTEST_SERIAL_OPTIONS) \
 		MFLAGS= MAKEFLAGS=
 

--- a/payloads/external/Memtest86Plus/Makefile
+++ b/payloads/external/Memtest86Plus/Makefile
@@ -15,12 +15,12 @@
 
 TAG-$(CONFIG_MEMTEST_MASTER)=origin/master
 NAME-$(CONFIG_MEMTEST_MASTER)=Master
-TAG-$(CONFIG_MEMTEST_STABLE)=7afa395fe8b11d681b27c38e204814ba643c2108
+TAG-$(CONFIG_MEMTEST_STABLE)=08dd5879f6518f79969be0cc96fc180e4293b90c
 NAME-$(CONFIG_MEMTEST_STABLE)=Stable
 
 project_name=Memtest86+
 project_dir=$(CURDIR)/memtest86plus
-project_git_repo=https://github.com/pcengines/memtest86plus.git
+project_git_repo=https://review.coreboot.org/memtest86plus.git
 
 all: build
 

--- a/src/mainboard/pcengines/apu2/Kconfig
+++ b/src/mainboard/pcengines/apu2/Kconfig
@@ -30,7 +30,6 @@ config BOARD_SPECIFIC_OPTIONS # dummy
 	select USE_BLOBS
 	select GENERIC_SPD_BIN
 	select PXE
-	select MEMTEST_DISABLE_SPD if MEMTEST_SECONDARY_PAYLOAD
 
 config MAINBOARD_DIR
 	string


### PR DESCRIPTION
All changes related to CB_NOSPD are reverted. Memtest86+ switched to mainline. Stable revision hash points to "spd: fix SMBus hang for AMD ML_A0 and ML_A1 stepping" which fixes the problem with SPD.
Memtest does not hang now.