### PR TITLE
Update ipxe legacy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ payloads/external/FILO/filo/
 payloads/external/GRUB2/grub2/
 payloads/external/SeaBIOS/seabios/
 payloads/external/sortbootorder/sortbootorder/
+payloads/external/iPXE/ipxe
 payloads/libpayload/install/
 util/crossgcc/acpica-unix-*/
 util/crossgcc/binutils-*/

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -100,6 +100,7 @@ spc :=
 spc +=
 $(spc) :=
 $(spc) +=
+comma := ,
 
 # files-in-dir-recursive,dir,files
 files-in-dir-recursive=$(filter $(1)%,$(2))
@@ -407,6 +408,7 @@ clean-for-update-target:
 	rm -f $(obj)/mainboard/$(MAINBOARDDIR)/romstage.inc
 	rm -f $(obj)/mainboard/$(MAINBOARDDIR)/bootblock.* $(obj)/mainboard/$(MAINBOARDDIR)/dsdt.*
 	rm -f $(obj)/cpu/x86/smm/smm_bin.c $(obj)/cpu/x86/smm/smm.* $(obj)/cpu/x86/smm/smm
+	$(MAKE) -C payloads/external/iPXE -f Makefile.inc clean
 	$(MAKE) -C payloads/external/SeaBIOS -f Makefile.inc clean OUT=$(abspath $(obj)) HOSTCC="$(HOSTCC)" CC="$(CC_x86_32)" LD="$(LD_x86_32)"
 
 clean-target:

--- a/payloads/external/SeaBIOS/Kconfig
+++ b/payloads/external/SeaBIOS/Kconfig
@@ -48,29 +48,6 @@ config SEABIOS_SERIAL_CONSOLE
 	depends on SEABIOS_ELTAN
 	default y
 
-config SKIP_PXE_LOAD
-	bool	"Allow disable of PXE ROM"
-	depends on SEABIOS_ELTAN
-	default n
-	help
-		Uses CMOS location to make skipping of the PXE ROM
-		user configurable. Requires SETUP to manipulate
-
-config CMOS_SKIP_PXE_LOC
-	hex		"CMOS location"
-	depends on SKIP_PXE_LOAD
-	default	0x32
-	help
-		Should match the network_boot entry in the CMOS layout
-
-config CMOS_SKIP_PXE_MASK
-	hex		"CMOS mask"
-	depends on SKIP_PXE_LOAD
-	default	0x02
-	help
-		Should match the network_boot entry in the CMOS layout
-		if the bit is set, the pxe boot rom will be disabled
-
 config SEABIOS_PS2_TIMEOUT
 	prompt "PS/2 keyboard controller initialization timeout (milliseconds)"
 	default 0

--- a/payloads/external/iPXE/Kconfig
+++ b/payloads/external/iPXE/Kconfig
@@ -1,0 +1,101 @@
+##
+## This file is part of the coreboot project.
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; version 2 of the License.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+
+config PXE
+	prompt "Add a PXE ROM"
+	def_bool y
+	depends on ARCH_X86
+
+if PXE
+menu "PXE Options"
+
+choice
+	prompt "PXE ROM to use"
+	default BUILD_IPXE
+
+config PXE_ROM
+	bool "Add an existing PXE ROM image"
+	help
+	  Select this option if you have a PXE ROM image that you would
+	  like to add to your ROM.
+
+config BUILD_IPXE
+	bool "Build and add an iPXE ROM"
+	help
+	  Select this option to fetch and build a ROM from the iPXE project.
+
+endchoice
+
+choice
+	prompt "iPXE version"
+	default IPXE_STABLE
+	depends on BUILD_IPXE
+
+config IPXE_STABLE
+	bool "2017.3"
+	help
+	  iPXE uses a rolling release with no stable version, for
+	  reproducibility, use the last commit of a given month as the
+	  'stable' version.
+	  This is iPXE from the end of March, 2017.
+
+config IPXE_MASTER
+	bool "master"
+	help
+	  Newest iPXE version.
+
+endchoice
+
+config PXE_ROM_FILE
+	string "PXE ROM filename"
+	depends on PXE_ROM
+	default "pxe.rom"
+	help
+	  The path and filename of the file to use as PXE ROM.
+
+config PXE_SERIAL_CONSOLE
+	bool "Enable serial console"
+	def_bool n
+	help
+	  Enable/disable iPXE serial console. Since SeaBIOS supports serial
+	  console this option might be helpful to avoid duplicated output.
+
+config PXE_ROM_ID
+	string "network card PCI IDs"
+	default "8086,157b"
+	help
+	  The comma-separated PCI vendor and device ID that would associate
+	  your PXE ROM to your network card.
+
+	  Example: 10ec,8168
+
+	  In the above example 10ec is the PCI vendor ID (in hex, but without
+	  the "0x" prefix) and 8168 specifies the PCI device ID of the
+	  network card (also in hex, without "0x" prefix).
+
+	  Under GNU/Linux you can run `lspci -nn` to list the IDs of your PCI devices.
+
+config PXE_CUSTOM_GENERAL_H
+	string "iPXE custom general.h file"
+	default "../../../../apu2-documentation/ipxe/general.h"
+	help
+	  This option allows user to customize feature set built-in into iPXE ROM.
+
+config PXE_CUSTOM_BOOTMENU_FILE
+	string "iPXE custom menu.ipxe file"
+	default "../../../../apu2-documentation/ipxe/menu.ipxe"
+	help
+	  This option allows user to customize boot menu for iPXE ROM.
+
+endmenu
+endif

--- a/payloads/external/iPXE/Makefile.inc
+++ b/payloads/external/iPXE/Makefile.inc
@@ -1,0 +1,84 @@
+STABLE_COMMIT_ID=fd6d1f4660a37d75acba1c64e2e5f137307bbc31
+
+TAG-$(CONFIG_IPXE_MASTER)=origin/master
+TAG-$(CONFIG_IPXE_STABLE)=$(STABLE_COMMIT_ID)
+
+project_name=iPXE
+project_dir=ipxe
+project_git_repo=https://git.ipxe.org/ipxe.git
+
+unexport KCONFIG_AUTOHEADER
+unexport KCONFIG_AUTOCONFIG
+unexport KCONFIG_DEPENDENCIES
+unexport KCONFIG_SPLITCONFIG
+unexport KCONFIG_TRISTATE
+unexport KCONFIG_NEGATIVES
+
+all: build
+
+$(project_dir):
+	echo "    Cloning $(project_name) from Git"
+	git clone $(project_git_repo) $(project_dir)
+
+fetch: $(project_dir)
+	cd $(project_dir); \
+		git show $(TAG-y) >/dev/null 2>&1 ; \
+		if [ $$? -ne 0 ] || [ "$(TAG-y)" = "origin/master" ]; then \
+			echo "    Fetching new commits from the $(project_name) repo"; \
+			git fetch; \
+		fi
+
+checkout: fetch
+	echo "    Checking out $(project_name) revision $(TAG-y)"
+	cd  $(project_dir); \
+		git checkout master; \
+		git branch -D coreboot 2>/dev/null; \
+		git checkout -b coreboot $(TAG-y)
+
+config: checkout
+ifeq ($(CONSOLE_SERIAL),yy)
+	cp "$(project_dir)/src/config/console.h" "$(project_dir)/src/config/console.h.cb"
+	cp "$(project_dir)/src/config/serial.h" "$(project_dir)/src/config/serial.h.cb"
+	sed 's|//#define\s*CONSOLE_SERIAL.*|#define CONSOLE_SERIAL|' "$(project_dir)/src/config/console.h" > "$(project_dir)/src/config/console.h.tmp"
+	mv "$(project_dir)/src/config/console.h.tmp" "$(project_dir)/src/config/console.h"
+	sed 's|#define\s*COMCONSOLE.*|#define COMCONSOLE $(IPXE_UART)|' "$(project_dir)/src/config/serial.h" > "$(project_dir)/src/config/serial.h.tmp"
+	sed 's|#define\s*COMSPEED.*|#define COMSPEED $(CONFIG_TTYS0_BAUD)|'  "$(project_dir)/src/config/serial.h.tmp" > "$(project_dir)/src/config/serial.h"
+endif
+ifneq ($(CONFIG_PXE_CUSTOM_GENERAL_H),)
+ifneq ("$(wildcard $(CONFIG_PXE_CUSTOM_GENERAL_H))","")
+	cat $(CONFIG_PXE_CUSTOM_GENERAL_H) > $(project_dir)/src/config/local/general.h
+else
+	echo "Error: File $(CONFIG_PXE_CUSTOM_GENERAL_H) does not exist"
+	false
+endif
+endif
+ifneq ($(CONFIG_PXE_CUSTOM_BOOTMENU_FILE),)
+ifneq ("$(wildcard $(CONFIG_PXE_CUSTOM_BOOTMENU_FILE))","")
+	cat $(CONFIG_PXE_CUSTOM_BOOTMENU_FILE) > $(project_dir)/src/menu.ipxe
+else
+	echo "Error: File $(CONFIG_PXE_CUSTOM_BOOTMENU_FILE) does not exist"
+	false
+endif
+endif
+
+build: config
+	echo "    MAKE       $(project_name) $(TAG-y)"
+ifneq ($(CONFIG_PXE_CUSTOM_BOOTMENU_FILE),)
+	$(MAKE) -C $(project_dir)/src bin/$(PXE_ROM_PCI_ID).rom EMBED=./menu.ipxe
+else
+	$(MAKE) -C $(project_dir)/src bin/$(PXE_ROM_PCI_ID).rom
+endif
+	cp $(project_dir)/src/bin/$(PXE_ROM_PCI_ID).rom $(project_dir)/ipxe.rom
+ifeq ($(CONSOLE_SERIAL),yy)
+	cp "$(project_dir)/src/config/console.h.cb" "$(project_dir)/src/config/console.h"
+	cp "$(project_dir)/src/config/serial.h.cb" "$(project_dir)/src/config/serial.h"
+endif
+
+clean:
+	test -d $(project_dir) && $(MAKE) -C $(project_dir)/src veryclean || exit 0
+	rm -f $(project_dir)/ipxe.rom
+
+distclean:
+	rm -rf $(project_dir)
+
+.PHONY: all fetch config build clean distclean

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -757,6 +757,8 @@ config SORTBOOTORDER
 	help
 	  APU series setup utility
 
+source "payloads/external/iPXE/Kconfig"
+
 endmenu
 
 menu "Debugging"

--- a/src/device/Kconfig
+++ b/src/device/Kconfig
@@ -348,35 +348,6 @@ config MBI_FILE
 	help
 	  The path and filename of the file to use as VGA BIOS.
 
-config PXE_ROM
-	bool "Add a PXE ROM image"
-	help
-	  Select this option if you have a PXE ROM image that you would
-	  like to add to your ROM.
-
-config PXE_ROM_FILE
-	string "PXE ROM filename"
-	depends on PXE_ROM
-	default "pxe.rom"
-	help
-	  The path and filename of the file to use as PXE ROM.
-
-config PXE_ROM_ID
-	string "network card PCI IDs"
-	depends on PXE_ROM
-	default "10ec,8168"
-	help
-	  The comma-separated PCI vendor and device ID that would associate
-	  your PXE ROM to your network card.
-
-	  Example: 10ec,8168
-
-	  In the above example 10ec is the PCI vendor ID (in hex, but without
-	  the "0x" prefix) and 8168 specifies the PCI device ID of the
-	  network card (also in hex, without "0x" prefix).
-
-	  Under GNU/Linux you can run `lspci -nn` to list the IDs of your PCI devices.
-
 config SOFTWARE_I2C
 	bool "Enable I2C controller emulation in software"
 	default n

--- a/src/mainboard/pcengines/apu2/Makefile.inc
+++ b/src/mainboard/pcengines/apu2/Makefile.inc
@@ -43,12 +43,6 @@ cbfs-files-y += bootorder_def
 bootorder_def-file := bootorder_def
 bootorder_def-type := raw
 
-# WIV20150205 add ipxe
-#cbfs-files-y += genroms/pxe.rom
-#genroms/pxe.rom-file := payloads/eltan/ipxe/10ec8168.rom
-#genroms/pxe.rom-type := raw
-# WIV20150205 add ipxe
-
 # WIV20150126 add boot order
 cbfs-files-y += bootorder
 bootorder-file := src/mainboard/$(MAINBOARDDIR)/bootorder
@@ -96,4 +90,39 @@ cbfs-files-y += spd.bin
 spd.bin-file := $(SPD_BIN)
 spd.bin-type := 0xab
 # WIV20141001 END ADD SPD FROM FILE
+
+# iPXE
+
+ifeq ($(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO),yy)
+IPXE_UART=COM$(call int-add,$(CONFIG_UART_FOR_CONSOLE) 1)
+endif
+
+ifeq ($(CONFIG_PXE_SERIAL_CONSOLE),y)
+IPXE_SERIAL_CONSOLE = $(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO)
+else
+IPXE_SERIAL_CONSOLE = n
+endif
+
+ifeq ($(CONFIG_PXE_ROM),y)
+PXE_ROM_FILE:=$(CONFIG_PXE_ROM_FILE)
+endif
+ifeq ($(CONFIG_BUILD_IPXE),y)
+PXE_ROM_FILE:=payloads/external/iPXE/ipxe/ipxe.rom
+endif
+
+cbfs-files-$(CONFIG_PXE_ROM)$(CONFIG_BUILD_IPXE) += genroms/pxe.rom
+genroms/pxe.rom-file := $(PXE_ROM_FILE)
+genroms/pxe.rom-type := raw
+
+payloads/external/iPXE/ipxe/ipxe.rom ipxe: $(DOTCONFIG)
+	$(MAKE) -C payloads/external/iPXE -f Makefile.inc all \
+	CROSS_COMPILE="$(CROSS_COMPILE_$(ARCH-ramstage-y))" \
+	PXE_ROM_PCI_ID=$(subst $(comma),,$(CONFIG_PXE_ROM_ID)) \
+	CONFIG_IPXE_MASTER=$(CONFIG_IPXE_MASTER) \
+	CONFIG_IPXE_STABLE=$(CONFIG_IPXE_STABLE) \
+	CONSOLE_SERIAL=$(IPXE_SERIAL_CONSOLE) \
+	IPXE_UART=$(IPXE_UART) \
+	CONFIG_TTYS0_BAUD=$(CONFIG_TTYS0_BAUD) \
+	CONFIG_PXE_CUSTOM_GENERAL_H=$(CONFIG_PXE_CUSTOM_GENERAL_H) \
+	CONFIG_PXE_CUSTOM_BOOTMENU_FILE=$(CONFIG_PXE_CUSTOM_BOOTMENU_FILE)
 

--- a/src/mainboard/pcengines/apu3/Makefile.inc
+++ b/src/mainboard/pcengines/apu3/Makefile.inc
@@ -43,12 +43,6 @@ cbfs-files-y += bootorder_def
 bootorder_def-file := bootorder_def
 bootorder_def-type := raw
 
-# WIV20150205 add ipxe
-#cbfs-files-y += genroms/pxe.rom
-#genroms/pxe.rom-file := payloads/eltan/ipxe/10ec8168.rom
-#genroms/pxe.rom-type := raw
-# WIV20150205 add ipxe
-
 # WIV20150126 add boot order
 cbfs-files-y += bootorder
 bootorder-file := src/mainboard/$(MAINBOARDDIR)/bootorder
@@ -96,4 +90,39 @@ cbfs-files-y += spd.bin
 spd.bin-file := $(SPD_BIN)
 spd.bin-type := 0xab
 # WIV20141001 END ADD SPD FROM FILE
+
+# iPXE
+
+ifeq ($(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO),yy)
+IPXE_UART=COM$(call int-add,$(CONFIG_UART_FOR_CONSOLE) 1)
+endif
+
+ifeq ($(CONFIG_PXE_SERIAL_CONSOLE),y)
+IPXE_SERIAL_CONSOLE = $(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO)
+else
+IPXE_SERIAL_CONSOLE = n
+endif
+
+ifeq ($(CONFIG_PXE_ROM),y)
+PXE_ROM_FILE:=$(CONFIG_PXE_ROM_FILE)
+endif
+ifeq ($(CONFIG_BUILD_IPXE),y)
+PXE_ROM_FILE:=payloads/external/iPXE/ipxe/ipxe.rom
+endif
+
+cbfs-files-$(CONFIG_PXE_ROM)$(CONFIG_BUILD_IPXE) += genroms/pxe.rom
+genroms/pxe.rom-file := $(PXE_ROM_FILE)
+genroms/pxe.rom-type := raw
+
+payloads/external/iPXE/ipxe/ipxe.rom ipxe: $(DOTCONFIG)
+	$(MAKE) -C payloads/external/iPXE -f Makefile.inc all \
+	CROSS_COMPILE="$(CROSS_COMPILE_$(ARCH-ramstage-y))" \
+	PXE_ROM_PCI_ID=$(subst $(comma),,$(CONFIG_PXE_ROM_ID)) \
+	CONFIG_IPXE_MASTER=$(CONFIG_IPXE_MASTER) \
+	CONFIG_IPXE_STABLE=$(CONFIG_IPXE_STABLE) \
+	CONSOLE_SERIAL=$(IPXE_SERIAL_CONSOLE) \
+	IPXE_UART=$(IPXE_UART) \
+	CONFIG_TTYS0_BAUD=$(CONFIG_TTYS0_BAUD) \
+	CONFIG_PXE_CUSTOM_GENERAL_H=$(CONFIG_PXE_CUSTOM_GENERAL_H) \
+	CONFIG_PXE_CUSTOM_BOOTMENU_FILE=$(CONFIG_PXE_CUSTOM_BOOTMENU_FILE)
 

--- a/src/mainboard/pcengines/apu5/Makefile.inc
+++ b/src/mainboard/pcengines/apu5/Makefile.inc
@@ -43,12 +43,6 @@ cbfs-files-y += bootorder_def
 bootorder_def-file := bootorder_def
 bootorder_def-type := raw
 
-# WIV20150205 add ipxe
-#cbfs-files-y += genroms/pxe.rom
-#genroms/pxe.rom-file := payloads/eltan/ipxe/10ec8168.rom
-#genroms/pxe.rom-type := raw
-# WIV20150205 add ipxe
-
 # WIV20150126 add boot order
 cbfs-files-y += bootorder
 bootorder-file := src/mainboard/$(MAINBOARDDIR)/bootorder
@@ -96,4 +90,39 @@ cbfs-files-y += spd.bin
 spd.bin-file := $(SPD_BIN)
 spd.bin-type := 0xab
 # WIV20141001 END ADD SPD FROM FILE
+
+# iPXE
+
+ifeq ($(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO),yy)
+IPXE_UART=COM$(call int-add,$(CONFIG_UART_FOR_CONSOLE) 1)
+endif
+
+ifeq ($(CONFIG_PXE_SERIAL_CONSOLE),y)
+IPXE_SERIAL_CONSOLE = $(CONFIG_CONSOLE_SERIAL)$(CONFIG_DRIVERS_UART_8250IO)
+else
+IPXE_SERIAL_CONSOLE = n
+endif
+
+ifeq ($(CONFIG_PXE_ROM),y)
+PXE_ROM_FILE:=$(CONFIG_PXE_ROM_FILE)
+endif
+ifeq ($(CONFIG_BUILD_IPXE),y)
+PXE_ROM_FILE:=payloads/external/iPXE/ipxe/ipxe.rom
+endif
+
+cbfs-files-$(CONFIG_PXE_ROM)$(CONFIG_BUILD_IPXE) += genroms/pxe.rom
+genroms/pxe.rom-file := $(PXE_ROM_FILE)
+genroms/pxe.rom-type := raw
+
+payloads/external/iPXE/ipxe/ipxe.rom ipxe: $(DOTCONFIG)
+	$(MAKE) -C payloads/external/iPXE -f Makefile.inc all \
+	CROSS_COMPILE="$(CROSS_COMPILE_$(ARCH-ramstage-y))" \
+	PXE_ROM_PCI_ID=$(subst $(comma),,$(CONFIG_PXE_ROM_ID)) \
+	CONFIG_IPXE_MASTER=$(CONFIG_IPXE_MASTER) \
+	CONFIG_IPXE_STABLE=$(CONFIG_IPXE_STABLE) \
+	CONSOLE_SERIAL=$(IPXE_SERIAL_CONSOLE) \
+	IPXE_UART=$(IPXE_UART) \
+	CONFIG_TTYS0_BAUD=$(CONFIG_TTYS0_BAUD) \
+	CONFIG_PXE_CUSTOM_GENERAL_H=$(CONFIG_PXE_CUSTOM_GENERAL_H) \
+	CONFIG_PXE_CUSTOM_BOOTMENU_FILE=$(CONFIG_PXE_CUSTOM_BOOTMENU_FILE)
 


### PR DESCRIPTION
Manually tested with SeaBIOS 1.11.0.1. No build errors or warnings.