### PR TITLE
disable SDR50 tuning in SD 2.0 mode

### DIFF
--- a/src/southbridge/amd/pi/hudson/sd.c
+++ b/src/southbridge/amd/pi/hudson/sd.c
@@ -27,27 +27,28 @@ static void sd_init(struct device *dev)
 
 	stepping = pci_read_config32(dev_find_slot(0, PCI_DEVFN(0x18, 3)), 0xFC);
 
-	struct southbridge_amd_pi_hudson_config *sd_chip =
-		(struct southbridge_amd_pi_hudson_config *)(dev->chip_info);
+	//struct southbridge_amd_pi_hudson_config *sd_chip =
+	//	(struct southbridge_amd_pi_hudson_config *)(dev->chip_info);
 
-	if (sd_chip->sd_mode == 3) {	/* SD 3.0 mode */
-		pci_write_config32(dev, 0xA4, 0x31FEC8B2);
-		pci_write_config32(dev, 0xA8, 0x00002503);
-		pci_write_config32(dev, 0xB0, 0x02180C19);
+	// if (sd_chip->sd_mode == 3) {	/* SD 3.0 mode */
+	// 	pci_write_config32(dev, 0xA4, 0x31FEC8B2);
+	// 	pci_write_config32(dev, 0xA8, 0x00002503);
+	// 	pci_write_config32(dev, 0xB0, 0x02180C19);
+	// 	pci_write_config32(dev, 0xD0, 0x0000078B);
+	// }
+	// else {				/* SD 2.0 mode */
+	if ((stepping & 0x0000000F) == 0) {	/* Stepping A0 */
+		pci_write_config32(dev, 0xA4, 0x21DE32B2);
+		pci_write_config32(dev, 0xB0, 0x01180C19);
+		pci_write_config32(dev, 0xD0, 0x0000058B);
+	}
+	else {					/* Stepping >= A1 */
+		pci_write_config32(dev, 0xA4, 0x21FE32B2);
+		pci_write_config32(dev, 0xA8, 0x00000070);
+		pci_write_config32(dev, 0xB0, 0x01180C19);
 		pci_write_config32(dev, 0xD0, 0x0000078B);
 	}
-	else {				/* SD 2.0 mode */
-		if ((stepping & 0x0000000F) == 0) {	/* Stepping A0 */
-			pci_write_config32(dev, 0xA4, 0x31DE32B2);
-			pci_write_config32(dev, 0xB0, 0x01180C19);
-			pci_write_config32(dev, 0xD0, 0x0000058B);
-		}
-		else {					/* Stepping >= A1 */
-			pci_write_config32(dev, 0xA4, 0x31FE3FB2);
-			pci_write_config32(dev, 0xB0, 0x01180C19);
-			pci_write_config32(dev, 0xD0, 0x0000078B);
-		}
-	}
+	//}
 }
 
 static struct device_operations sd_ops = {


### PR DESCRIPTION
`0xA8` register should also be properly initialized in SD 2.0 mode (present in legacy). 