### PR TITLE
mainboard/apu2: add possibility to enable SP5100 watchdog on boot

### DIFF
--- a/src/mainboard/pcengines/apu2/Kconfig
+++ b/src/mainboard/pcengines/apu2/Kconfig
@@ -125,4 +125,15 @@ config FORCE_MPCIE2_CLK
 	help
 	  If no card is attached to mPCIe2 slot, say N.
 
+config ENABLE_WATCHDOG_ON_BOOT
+	bool "Enable SP5100 watchdog on boot"
+	default n
+	help
+	  This enables the watchdog timer on boot.
+
+config WATCHDOG_TIMEOUT
+	int "Watchdog timeout value"
+	depends on ENABLE_WATCHDOG_ON_BOOT
+	default 300
+
 endif # BOARD_PCENGINES_APU2

--- a/src/mainboard/pcengines/apu2/romstage.c
+++ b/src/mainboard/pcengines/apu2/romstage.c
@@ -126,6 +126,26 @@ void cache_as_ram_main(unsigned long bist, unsigned long cpu_init_detectedx)
 #endif
 
 		*((u32 *)(ACPI_MMIO_BASE + MISC_BASE+FCH_MISC_REG04)) = data;
+
+
+#if IS_ENABLED(CONFIG_ENABLE_WATCHDOG_ON_BOOT)
+		{
+			//
+			// configure the watchdog
+			//
+			volatile u32 *ptr = (u32 *)(ACPI_MMIO_BASE + WATCHDOG_BASE);
+
+			// enable
+			*ptr &= ~(1 << 3);
+			*ptr |= (1 << 0);
+			// configure timeout
+			*(ptr + 1) = (u16)CONFIG_WATCHDOG_TIMEOUT;
+			// trigger
+			*ptr |= (1 << 7);
+
+			printk(BIOS_ALERT, "Watchdog is enabled, state = 0x%x, time = %d\n", *ptr, *(ptr + 1));
+		}
+#endif
 	}
 
 	/* Halt if there was a built in self test failure */


### PR DESCRIPTION
This adds setup option to enable the SP5100 watchdog on boot.
Could be useful in high-accessibility systems.

To test:
1. Enter the sortbootorder setup menu.
2. Wait for the timeout, after which platform should reboot by itself.

Things to consider:
1. OS shall support the SP5100_tco watchdog (module loaded)
2. If OS is not supporting the watchdog or it is not enabled, the timeout will trip and platform will reboot itself.

Signed-off-by: Kamil Wcislo <mek.xgt@gmail.com>