### PR TITLE
payloads/external/iPXE: fix iXPE general.h and bootmenu path

### DIFF
--- a/payloads/external/iPXE/Kconfig
+++ b/payloads/external/iPXE/Kconfig
@@ -90,13 +90,13 @@ config PXE_ROM_ID
 
 config PXE_CUSTOM_GENERAL_H
 	string "iPXE custom general.h file"
-	default "../../../../apu2-documentation/ipxe/general.h"
+	default "general.h"
 	help
 	  This option allows user to customize feature set built-in into iPXE ROM.
 
 config PXE_CUSTOM_BOOTMENU_FILE
 	string "iPXE custom menu.ipxe file"
-	default "../../../../apu2-documentation/ipxe/menu.ipxe"
+	default "menu.ipxe"
 	help
 	  This option allows user to customize boot menu for iPXE ROM.
 


### PR DESCRIPTION
Change-Id: Ibe7a68d13dadf69d8b4218f2db5f052474489818
Signed-off-by: Piotr Król <piotr.krol@3mdeb.com>