### PR TITLE
pcengines/apu{1,2}: fix BIOS Release Date format in SMBIOS

### DIFF
--- a/src/mainboard/pcengines/apu1/mainboard.c
+++ b/src/mainboard/pcengines/apu1/mainboard.c
@@ -31,9 +31,6 @@
 #include "gpio_ftns.h"
 #include "bios_knobs.h"
 
-static void change_build_date_format(void);
-extern char coreboot_dmi_date[];
-
 /***********************************************************
  * These arrays set up the FCH PCI_INTR registers 0xC00/0xC01.
  * This table is responsible for physically routing the PIC and
@@ -212,7 +209,6 @@ static void config_addon_uart(void)
  **********************************************/
 static void mainboard_enable(struct device *dev)
 {
-	change_build_date_format();
 	printk(BIOS_INFO, "Mainboard " CONFIG_MAINBOARD_PART_NUMBER " Enable.\n");
 
 	config_gpio_mux();
@@ -333,18 +329,3 @@ struct chip_operations mainboard_ops = {
 	.enable_dev = mainboard_enable,
 	.final = mainboard_final,
 };
-
-static void change_build_date_format()
-{
-	char tmp[15];
-    
-/* 
- * Following lines change format of date in coreboot_dmi_date[]
- * from "dd/mm/yyyy" to "yyyymmdd", as is expected by vendor.
- */
-	strcpy(tmp, coreboot_dmi_date);
-	strncpy(coreboot_dmi_date,   tmp+6, 4);
-	strncpy(coreboot_dmi_date+4, tmp+3, 2);
-	strncpy(coreboot_dmi_date+6, tmp,   2);
-	coreboot_dmi_date[8] = '\0';
-}

--- a/src/mainboard/pcengines/apu2/mainboard.c
+++ b/src/mainboard/pcengines/apu2/mainboard.c
@@ -43,8 +43,6 @@
 #define SEC_REG_SERIAL_ADDR 0x1000
 #define MAX_SERIAL_LEN	    10
 
-static void change_build_date_format(void);
-extern char coreboot_dmi_date[];
 
 /***********************************************************
  * These arrays set up the FCH PCI_INTR registers 0xC00/0xC01.
@@ -202,7 +200,6 @@ static void config_gpio_mux(void)
 
 static void mainboard_enable(struct device *dev)
 {
-	change_build_date_format();
 	bool scon = check_console();
 
 	config_gpio_mux();
@@ -363,18 +360,3 @@ struct chip_operations mainboard_ops = {
 	.enable_dev = mainboard_enable,
 	.final = mainboard_final,
 };
-
-static void change_build_date_format()
-{
-	char tmp[15];
-
-/*
- * Following lines change format of date in coreboot_dmi_date[]
- * from "dd/mm/yyyy" to "yyyymmdd", as is expected by vendor.
- */
-	strcpy(tmp, coreboot_dmi_date);
-	strncpy(coreboot_dmi_date,   tmp+6, 4);
-	strncpy(coreboot_dmi_date+4, tmp+3, 2);
-	strncpy(coreboot_dmi_date+6, tmp,   2);
-	coreboot_dmi_date[8] = '\0';
-}


### PR DESCRIPTION
Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>