### PR TITLE
agesawrapper.c: check if HOP_COUNT_TABLE exists before AmdInitLate()

### DIFF
--- a/src/northbridge/amd/pi/agesawrapper.c
+++ b/src/northbridge/amd/pi/agesawrapper.c
@@ -255,11 +255,17 @@ AGESA_STATUS agesawrapper_amdinitlate(void)
 	AGESA_STATUS Status;
 	AMD_INTERFACE_PARAMS AmdParamStruct;
 	AMD_LATE_PARAMS *AmdLateParams;
+	AGESA_BUFFER_PARAMS BufParams;
 
 	LibAmdMemFill (&AmdParamStruct,
 		       0,
 		       sizeof(AMD_INTERFACE_PARAMS),
 		       &(AmdParamStruct.StdHeader));
+
+	LibAmdMemFill (&BufParams,
+		       0,
+		       sizeof(AGESA_BUFFER_PARAMS),
+		       &(BufParams.StdHeader));
 
 	AmdParamStruct.AgesaFunctionName = AMD_INIT_LATE;
 	AmdParamStruct.AllocationMethod = PostMemDram;
@@ -274,6 +280,15 @@ AGESA_STATUS agesawrapper_amdinitlate(void)
 	AmdLateParams = (AMD_LATE_PARAMS *)AmdParamStruct.NewStructPtr;
 	AmdLateParams->GnbLateConfiguration.GnbIoapicId = CONFIG_MAX_CPUS + 1;
 	AmdLateParams->GnbLateConfiguration.FchIoapicId = CONFIG_MAX_CPUS;
+
+	/* Code for creating CDIT requires hop count table. If it is not
+	 * present AGESA_ERROR is returned, which confuses users. */
+	BufParams.BufferHandle = HOP_COUNT_TABLE_HANDLE;
+	Status = HeapManagerCallout(AGESA_LOCATE_BUFFER, 0, &BufParams);
+	if (Status != AGESA_SUCCESS) {
+		AmdLateParams->PlatformConfig.UserOptionCdit = 0;
+	}
+
 	Status = AmdInitLate(AmdLateParams);
 	if (Status != AGESA_SUCCESS) {
 		agesawrapper_amdreadeventlog(AmdLateParams->StdHeader.HeapStatus);


### PR DESCRIPTION
If HOP_COUNT_TABLE doesn't exist AmdInitLate() returns error when
creating CDIT, which scaries users. This patch checks if mentioned
table exists and turns off CDIT generation when it doesn't.

After this patch AGESA_UNSUPPORTED is returned due to a bug in
AGESA which cannot be walked around without disabling DMI table
generation (`AGESA_STATUS Status = TRUE`, present in open source
version of AGESA too).

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>