### PR TITLE
BiosCallOuts.c: don't enable EHCI0 in AGESA for apu2 even if requested

### DIFF
--- a/src/mainboard/pcengines/apu2/BiosCallOuts.c
+++ b/src/mainboard/pcengines/apu2/BiosCallOuts.c
@@ -110,7 +110,12 @@ static AGESA_STATUS Fch_Oem_config(UINT32 Func, UINT32 FchData, VOID *ConfigPtr)
 
 		/* EHCI configuration */
 		FchParams->Usb.Ehci3Enable = !IS_ENABLED(CONFIG_HUDSON_XHCI_ENABLE);
-		FchParams->Usb.Ehci1Enable = check_ehci0();
+		if (IS_ENABLED(CONFIG_BOARD_PCENGINES_APU2)) {
+			// Disable EHCI 0 (port 0 to 3)
+			FchParams->Usb.Ehci1Enable = FALSE;
+		} else {
+			FchParams->Usb.Ehci1Enable = check_ehci0();
+		}
 		FchParams->Usb.Ehci2Enable = TRUE;	// Enable EHCI 1 ( port 4 to 7) port 4 and 5 to EHCI header port 6 and 7 to PCIe slot.
 
 		/* sata configuration */


### PR DESCRIPTION
Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>