### PR TITLE
src/mainboard/pcengines/apu1/romstage.c: add missing includes

### DIFF
--- a/src/mainboard/pcengines/apu1/romstage.c
+++ b/src/mainboard/pcengines/apu1/romstage.c
@@ -16,6 +16,9 @@
  */
 
 #include <string.h>
+#include <device/pci_def.h>
+#include <device/pci_ops.h>
+#include <device/pnp.h>
 #include <northbridge/amd/agesa/state_machine.h>
 #include <southbridge/amd/cimx/cimx_util.h>
 #include <superio/nuvoton/common/nuvoton.h>


### PR DESCRIPTION
Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>