### PR TITLE
Fixing sign-of-life message SVI2

### DIFF
--- a/src/mainboard/pcengines/apu2/romstage.c
+++ b/src/mainboard/pcengines/apu2/romstage.c
@@ -176,9 +176,9 @@ void cache_as_ram_main(unsigned long bist, unsigned long cpu_init_detectedx)
 	/* Disable SVI2 controller to wait for command completion */
 	val = pci_read_config32(PCI_DEV(0, 0x18, 5), 0x12C);
 	if (val & (1 << 30)) {
-		printk(BIOS_ALERT, "SVI2 Wait completion disabled\n");
+		printk(BIOS_DEBUG, "SVI2 Wait completion disabled\n");
 	} else {
-		printk(BIOS_ALERT, "Disabling SVI2 Wait completion\n");
+		printk(BIOS_DEBUG, "Disabling SVI2 Wait completion\n");
 		val |= (1 << 30);
 		pci_write_config32(PCI_DEV(0, 0x18, 5), 0x12C, val);
 	}


### PR DESCRIPTION
SVI wait completion message is now unvisible in sign-of-life