### PR TITLE
Revert "cpu/amd/*/*/acpi/: Use 'Device()' instead of 'Processor()'"

### DIFF
--- a/src/cpu/amd/agesa/family14/acpi/cpu.asl
+++ b/src/cpu/amd/agesa/family14/acpi/cpu.asl
@@ -16,14 +16,19 @@
  *
  */
 Scope (\_PR) {		/* define processor scope */
-
-	Device (C000) {
-	Name (_HID, "ACPI0007")
-	Name (_UID, 0)
+	Processor(
+		C000,		/* name space name, align with BLDCFG_PROCESSOR_SCOPE_NAME[01] */
+		0,		/* Unique number for this processor */
+		0x810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
 
-	Device (C001) {
-	Name (_HID, "ACPI0007")
-	Name (_UID, 1)
+	Processor(
+		C001,		/* name space name */
+		1,		/* Unique number for this processor */
+		0x810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
 } /* End _PR scope */

--- a/src/cpu/amd/agesa/family15tn/acpi/cpu.asl
+++ b/src/cpu/amd/agesa/family15tn/acpi/cpu.asl
@@ -11,49 +11,66 @@
  * GNU General Public License for more details.
  */
 
-/*
- * Processor Object
- *
- */
-Scope (\_PR) {	/* define processor scope */
+	/*
+	 * Processor Object
+	 *
+	 */
+	Scope (\_PR) {		/* define processor scope */
+		Processor(
+			P000,		/* name space name */
+			0,		/* Unique number for this processor */
+			0x810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
 
-	Device (P000) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 0)
-	}
-
-	Device (P001) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 1)
-	}
-
-	Device (P002) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 2)
-	}
-
-	Device (P003) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 3)
-	}
-
-	Device (P004) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 4)
-	}
-
-	Device (P005) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 5)
-	}
-
-	Device (P006) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 6)
-	}
-
-	Device (P007) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 7)
-	}
-} /* End _PR scope */
+		Processor(
+			P001,		/* name space name */
+			1,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P002,		/* name space name */
+			2,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P003,		/* name space name */
+			3,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P004,		/* name space name */
+			4,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P005,		/* name space name */
+			5,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P006,		/* name space name */
+			6,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P007,		/* name space name */
+			7,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+	} /* End _PR scope */

--- a/src/cpu/amd/agesa/family16kb/acpi/cpu.asl
+++ b/src/cpu/amd/agesa/family16kb/acpi/cpu.asl
@@ -15,44 +15,62 @@
  * Processor Object
  *
  */
-Scope (\_PR) {/* define processor scope */
-	Device (P000) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 0)
+Scope (\_PR) {		/* define processor scope */
+	Processor(
+		P000,		/* name space name */
+		0,			/* Unique number for this processor */
+		0x810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
 
-	Device (P001) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 1)
+	Processor(
+		P001,		/* name space name */
+		1,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P002) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 2)
+	Processor(
+		P002,		/* name space name */
+		2,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P003) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 3)
+	Processor(
+		P003,		/* name space name */
+		3,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P004) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 4)
+	Processor(
+		P004,		/* name space name */
+		4,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P005) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 5)
+	Processor(
+		P005,		/* name space name */
+		5,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P006) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 6)
+	Processor(
+		P006,		/* name space name */
+		6,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P007) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 7)
+	Processor(
+		P007,		/* name space name */
+		7,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
 } /* End _PR scope */

--- a/src/cpu/amd/pi/00630F01/acpi/cpu.asl
+++ b/src/cpu/amd/pi/00630F01/acpi/cpu.asl
@@ -11,49 +11,94 @@
  * GNU General Public License for more details.
  */
 
-/*
- * Processor Object
- *
- */
-Scope (\_PR) {	/* define processor scope */
+	/*
+	 * Processor Object
+	 *
+	 */
+	Scope (\_PR) {      /* define processor scope */
+		Processor(
+			P000,       /* name space name */
+			0,          /* Unique core number for this processor within a socket */
+			0x810,      /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
 
-	Device (P000) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 0)
-	}
-
-	Device (P001) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 1)
-	}
-
-	Device (P002) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 2)
-	}
-
-	Device (P003) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 3)
-	}
-
-	Device (P004) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 4)
-	}
-
-	Device (P005) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 5)
-	}
-
-	Device (P006) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 6)
-	}
-
-	Device (P007) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 7)
-	}
-} /* End _PR scope */
+		Processor(
+			P001,       /* name space name */
+			1,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P002,       /* name space name */
+			2,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P003,       /* name space name */
+			3,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P004,       /* name space name */
+			4,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P005,       /* name space name */
+			5,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P006,       /* name space name */
+			6,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P007,       /* name space name */
+			7,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P008,       /* name space name */
+			8,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P009,       /* name space name */
+			9,          /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P010,       /* name space name */
+			10,         /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P011,       /* name space name */
+			11,         /* Unique core number for this processor within a socket */
+			0x0810,     /* PBLK system I/O address !hardcoded! */
+			0x06        /* PBLKLEN for boot processor */
+			) {
+		}
+	} /* End _PR scope */

--- a/src/cpu/amd/pi/00660F01/acpi/cpu.asl
+++ b/src/cpu/amd/pi/00660F01/acpi/cpu.asl
@@ -15,45 +15,62 @@
  * Processor Object
  *
  */
-Scope (\_PR) {	/* define processor scope */
-
-	Device (P000) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 0)
+Scope (\_PR) {		/* define processor scope */
+	Processor(
+		P000,		/* name space name */
+		0,			/* Unique number for this processor */
+		0x810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
 
-	Device (P001) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 1)
+	Processor(
+		P001,		/* name space name */
+		1,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P002) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 2)
+	Processor(
+		P002,		/* name space name */
+		2,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P003) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 3)
+	Processor(
+		P003,		/* name space name */
+		3,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P004) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 4)
+	Processor(
+		P004,		/* name space name */
+		4,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P005) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 5)
+	Processor(
+		P005,		/* name space name */
+		5,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P006) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 6)
+	Processor(
+		P006,		/* name space name */
+		6,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
-
-	Device (P007) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 7)
+	Processor(
+		P007,		/* name space name */
+		7,			/* Unique number for this processor */
+		0x0810,		/* PBLK system I/O address !hardcoded! */
+		0x06		/* PBLKLEN for boot processor */
+		) {
 	}
 } /* End _PR scope */

--- a/src/cpu/amd/pi/00730F01/acpi/cpu.asl
+++ b/src/cpu/amd/pi/00730F01/acpi/cpu.asl
@@ -11,49 +11,66 @@
  * GNU General Public License for more details.
  */
 
-/*
- * Processor Object
- *
- */
-Scope (\_PR) {	/* define processor scope */
+	/*
+	 * Processor Object
+	 *
+	 */
+	Scope (\_PR) {		/* define processor scope */
+		Processor(
+			P000,		/* name space name */
+			0,		/* Unique number for this processor */
+			0x810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
 
-	Device (P000) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 0)
-	}
-
-	Device (P001) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 1)
-	}
-
-	Device (P002) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 2)
-	}
-
-	Device (P003) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 3)
-	}
-
-	Device (P004) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 4)
-	}
-
-	Device (P005) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 5)
-	}
-
-	Device (P006) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 6)
-	}
-
-	Device (P007) {
-	Name(_HID, "ACPI0007")
-	Name(_UID, 7)
-	}
-} /* End _PR scope */
+		Processor(
+			P001,		/* name space name */
+			1,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P002,		/* name space name */
+			2,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P003,		/* name space name */
+			3,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P004,		/* name space name */
+			4,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P005,		/* name space name */
+			5,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P006,		/* name space name */
+			6,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+		Processor(
+			P007,		/* name space name */
+			7,		/* Unique number for this processor */
+			0x0810,		/* PBLK system I/O address !hardcoded! */
+			0x06		/* PBLKLEN for boot processor */
+			) {
+		}
+	} /* End _PR scope */


### PR DESCRIPTION
This reverts commit 2c34892efd0aa2dd4491db81e63c9596502753b3.