### PR TITLE
Watchdog fixes

### DIFF
--- a/src/mainboard/pcengines/apu2/OemCustomize.c
+++ b/src/mainboard/pcengines/apu2/OemCustomize.c
@@ -16,6 +16,8 @@
 #include <AGESA.h>
 #include <northbridge/amd/agesa/state_machine.h>
 #include "bios_knobs.h"
+#include <smp/node.h>
+#include <Fch/Fch.h>
 
 static const PCIe_PORT_DESCRIPTOR PortList[] = {
 	{
@@ -82,6 +84,38 @@ void board_BeforeInitEarly(struct sysinfo *cb, AMD_EARLY_PARAMS *InitEarly)
 	if (check_boost()) {
 		InitEarly->PlatformConfig.CStateMode = CStateModeC6;
 		InitEarly->PlatformConfig.CpbMode = CpbModeAuto;
+	}
+
+	if (boot_cpu()) {
+		volatile u32 *ptr = (u32 *)(ACPI_MMIO_BASE + WATCHDOG_BASE);
+
+		/*
+		 * Set PMxBE[RstToCpuPwrGdEn] = 1: FCH toggles CpuPwrGd on every reset.
+		 * Without it, after watchdog causes a restart, D18F5x84[CmpCap]
+		 * (number of cores on the node) sometimes reads as 0. Because of that
+		 * AGESA hangs in subsequent InitReset calls, until next cold reset.
+		 */
+		volatile u8 *rc1 = (u8 *)(ACPI_MMIO_BASE + PMIO_BASE + FCH_PMIOA_REGBE);
+		*rc1 |= 0x80;
+
+		u16 watchdog_timeout = get_watchdog_timeout();
+
+		if (watchdog_timeout == 0) {
+			// watchdog disabled - default state
+			printk(BIOS_WARNING, "Watchdog is disabled\n");
+		} else {
+			// bit 1 (WatchdogFired) is write-1-to-clear, needs to be preserved
+			u32 val = *ptr & ~(1 << 1);
+			// enable
+			*ptr = val | (1 << 0);
+			// configure timeout
+			*(ptr + 1) = (u16) watchdog_timeout;
+			// trigger
+			val = *ptr & ~(1 << 1);
+			*ptr = val | (1 << 7);
+
+			printk(BIOS_WARNING, "Watchdog is enabled, state = 0x%x, time = %d\n", *ptr, *(ptr + 1));
+		}
 	}
 }
 

--- a/src/mainboard/pcengines/apu2/OemCustomize.c
+++ b/src/mainboard/pcengines/apu2/OemCustomize.c
@@ -18,6 +18,7 @@
 #include "bios_knobs.h"
 #include <smp/node.h>
 #include <Fch/Fch.h>
+#include <amdblocks/acpimmio.h>
 
 static const PCIe_PORT_DESCRIPTOR PortList[] = {
 	{
@@ -95,8 +96,7 @@ void board_BeforeInitEarly(struct sysinfo *cb, AMD_EARLY_PARAMS *InitEarly)
 		 * (number of cores on the node) sometimes reads as 0. Because of that
 		 * AGESA hangs in subsequent InitReset calls, until next cold reset.
 		 */
-		volatile u8 *rc1 = (u8 *)(ACPI_MMIO_BASE + PMIO_BASE + FCH_PMIOA_REGBE);
-		*rc1 |= 0x80;
+		pm_write8(FCH_PMIOA_REGBE, pm_read8(FCH_PMIOA_REGBE) | 0x80);
 
 		u16 watchdog_timeout = get_watchdog_timeout();
 

--- a/src/mainboard/pcengines/apu2/romstage.c
+++ b/src/mainboard/pcengines/apu2/romstage.c
@@ -161,24 +161,5 @@ void board_BeforeInitReset(struct sysinfo *cb, AMD_RESET_PARAMS *Reset)
 			misc_write32(FCH_MISC_REG04, data);
 			printk(BIOS_DEBUG, "force mPCIe clock enabled\n");
 		}
-
-		volatile u32 *ptr = (u32 *)(ACPI_MMIO_BASE + WATCHDOG_BASE);
-		u16 watchdog_timeout = get_watchdog_timeout();
-
-		if (watchdog_timeout == 0) {
-			//disable watchdog
-			printk(BIOS_WARNING, "Watchdog is disabled\n");
-			*ptr |= (1 << 3);
-		} else {
-			// enable
-			*ptr &= ~(1 << 3);
-			*ptr |= (1 << 0);
-			// configure timeout
-			*(ptr + 1) = (u16) watchdog_timeout;
-			// trigger
-			*ptr |= (1 << 7);
-
-			printk(BIOS_WARNING, "Watchdog is enabled, state = 0x%x, time = %d\n", *ptr, *(ptr + 1));
-		}
 	}
 }


### PR DESCRIPTION
Platform hanged without setting RstToCpuPwrGdEn.

Code for enabling watchdog is now in board_BeforeInitEarly, as hardware
is not enabled before InitReset. It didn't work on first boot after
power cycle.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>