### PR TITLE
gitmodules: use absolute URL for qc_blobs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -48,6 +48,6 @@
 	update = none
 [submodule "3rdparty/qc_blobs"]
 	path = 3rdparty/qc_blobs
-	url = ../qc_blobs.git
+	url = https://review.coreboot.org/qc_blobs.git
 	update = none
 	ignore = dirty


### PR DESCRIPTION
Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>