### PR TITLE
util/cbmem: fix printing strings from DRTM event log

### DIFF
--- a/util/cbmem/cbmem.c
+++ b/util/cbmem/cbmem.c
@@ -727,6 +727,7 @@ static void parse_drtm_tcpa_log(const struct tcpa_spec_entry *tcpa_log)
 	static uint8_t zero_block[sizeof(struct tcpa_spec_entry)];
 	struct tcpa_log_entry *log_entry;
 	uint32_t counter = 0;
+	uint32_t len;
 
 	printf("DRTM TCPA log:\n");
 	printf("\tSpecification: %d.%d%d", tcpa_log->spec_version_major,
@@ -735,9 +736,10 @@ static void parse_drtm_tcpa_log(const struct tcpa_spec_entry *tcpa_log)
 	printf("\tPlatform class: %s\n", tcpa_log->platform_class == 0 ? "PC Client" :
 					 tcpa_log->platform_class == 1 ? "Server" :
 									 "Unknown");
-	if (tcpa_log->vendor_info_size != 0) {
-		current += tcpa_log->vendor_info_size;
-		printf("\tVendor information: %s\n", tcpa_log->vendor_info);
+	len = tcpa_log->vendor_info_size;
+	if (len != 0) {
+		current += len;
+		printf("\tVendor information: %.*s\n", len, tcpa_log->vendor_info);
 	} else {
 		printf("\tNo vendor information provided\n");
 	}
@@ -754,9 +756,10 @@ static void parse_drtm_tcpa_log(const struct tcpa_spec_entry *tcpa_log)
 		printf("\tDigest: ");
 		print_hex(log_entry->digest, SHA1_DIGEST_SIZE);
 		current += sizeof(struct tcpa_log_entry);
-		if (log_entry->event_data_size != 0) {
-			current += log_entry->event_data_size;
-			printf("\tEvent data: %s\n", log_entry->event);
+		len = log_entry->event_data_size;
+		if (len != 0) {
+			current += len;
+			printf("\tEvent data: %.*s\n", len, log_entry->event);
 		} else {
 			printf("\tEvent data not provided\n");
 		}
@@ -817,6 +820,7 @@ static void parse_drtm_tpm2_log(const tcg_efi_spec_id_event *tpm2_log)
 	static uint8_t zero_block[10]; /* Only pcr index, event type and digest count */
 	tcg_pcr_event2_header *log_entry;
 	uint32_t counter = 0;
+	uint32_t len;
 
 	printf("DRTM TPM2 log:\n");
 	printf("\tSpecification: %d.%d%d\n", tpm2_log->spec_version_major,
@@ -825,9 +829,10 @@ static void parse_drtm_tpm2_log(const tcg_efi_spec_id_event *tpm2_log)
 	printf("\tPlatform class: %s\n", tpm2_log->platform_class == 0 ? "PC Client" :
 					 tpm2_log->platform_class == 1 ? "Server" :
 									 "Unknown");
-	if (tpm2_log->vendor_info_size != 0) {
-		current += tpm2_log->vendor_info_size;
-		printf("\tVendor information: %s\n", tpm2_log->vendor_info);
+	len = tpm2_log->vendor_info_size;
+	if (len != 0) {
+		current += len;
+		printf("\tVendor information: %.*s\n", len, tpm2_log->vendor_info);
 	} else {
 		printf("\tNo vendor information provided\n");
 	}
@@ -850,13 +855,14 @@ static void parse_drtm_tpm2_log(const tcg_efi_spec_id_event *tpm2_log)
 			printf("\tNo digests in this log entry\n");
 		}
 		/* Now the vend size and event is left to be parsed */
-		if (*(uint32_t *)current != 0) {
-			printf("\tEvent data: %s\n", (uint8_t *)current + sizeof(uint32_t));
-			current += *(uint32_t *)current;
+		len = *(uint32_t *)current;
+		current += sizeof(uint32_t);
+		if (len != 0) {
+			printf("\tEvent data: %.*s\n", len, (uint8_t *)current);
+			current += len;
 		} else {
 			printf("\tEvent data not provided\n");
 		}
-		current += sizeof(uint32_t);
 	}
 }
 


### PR DESCRIPTION
Strings in vendor info and event data do not have to be null-terminated.
Before this patch, PCR number (which was non-printable ASCII)  was printed
at the end of the line. Now, this is truncated to the length specified by
the event structure.

In fact, those fields do not have to be strings at all. Binary data is
printed to the first zero byte, which in most cases is the first byte.
There is no easy and efficient way to test whether it is binary or text.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>