### PR TITLE
Revert "Revert "cpu/amd/*/*/acpi/: Use 'Device()' instead of 'Process…

### DIFF
--- a/src/cpu/amd/agesa/family14/acpi/cpu.asl
+++ b/src/cpu/amd/agesa/family14/acpi/cpu.asl
@@ -4,20 +4,15 @@
  * Processor Object
  *
  */
-Scope (\_PR) {		/* define processor scope */
-	Processor(
-		C000,		/* name space name, align with BLDCFG_PROCESSOR_SCOPE_NAME[01] */
-		0,		/* Unique number for this processor */
-		0x810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+Scope (\_SB) {		/* define processor scope */
+
+	Device (C000) {
+	Name (_HID, "ACPI0007")
+	Name (_UID, 0)
 	}
 
-	Processor(
-		C001,		/* name space name */
-		1,		/* Unique number for this processor */
-		0x810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+	Device (C001) {
+	Name (_HID, "ACPI0007")
+	Name (_UID, 1)
 	}
 } /* End _SB scope */

--- a/src/cpu/amd/agesa/family15tn/acpi/cpu.asl
+++ b/src/cpu/amd/agesa/family15tn/acpi/cpu.asl
@@ -1,65 +1,48 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-	/*
-	 * Processor Object
-	 *
-	 */
-	Scope (\_PR) {		/* define processor scope */
-		Processor(
-			P000,		/* name space name */
-			0,		/* Unique number for this processor */
-			0x810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
+/*
+ * Processor Object
+ *
+ */
+Scope (\_SB) {	/* define processor scope */
 
-		Processor(
-			P001,		/* name space name */
-			1,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P002,		/* name space name */
-			2,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P003,		/* name space name */
-			3,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P004,		/* name space name */
-			4,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P005,		/* name space name */
-			5,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P006,		/* name space name */
-			6,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P007,		/* name space name */
-			7,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-	} /* End _PR scope */
+	Device (P000) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 0)
+	}
+
+	Device (P001) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 1)
+	}
+
+	Device (P002) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 2)
+	}
+
+	Device (P003) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 3)
+	}
+
+	Device (P004) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 4)
+	}
+
+	Device (P005) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 5)
+	}
+
+	Device (P006) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 6)
+	}
+
+	Device (P007) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 7)
+	}
+} /* End _SB scope */

--- a/src/cpu/amd/agesa/family16kb/acpi/cpu.asl
+++ b/src/cpu/amd/agesa/family16kb/acpi/cpu.asl
@@ -4,62 +4,44 @@
  * Processor Object
  *
  */
-Scope (\_PR) {		/* define processor scope */
-	Processor(
-		P000,		/* name space name */
-		0,			/* Unique number for this processor */
-		0x810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+Scope (\_SB) {/* define processor scope */
+	Device (P000) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 0)
 	}
 
-	Processor(
-		P001,		/* name space name */
-		1,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+	Device (P001) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 1)
 	}
-	Processor(
-		P002,		/* name space name */
-		2,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+
+	Device (P002) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 2)
 	}
-	Processor(
-		P003,		/* name space name */
-		3,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+
+	Device (P003) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 3)
 	}
-	Processor(
-		P004,		/* name space name */
-		4,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+
+	Device (P004) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 4)
 	}
-	Processor(
-		P005,		/* name space name */
-		5,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+
+	Device (P005) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 5)
 	}
-	Processor(
-		P006,		/* name space name */
-		6,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+
+	Device (P006) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 6)
 	}
-	Processor(
-		P007,		/* name space name */
-		7,			/* Unique number for this processor */
-		0x0810,		/* PBLK system I/O address !hardcoded! */
-		0x06		/* PBLKLEN for boot processor */
-		) {
+
+	Device (P007) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 7)
 	}
 } /* End _SB scope */

--- a/src/cpu/amd/pi/00730F01/acpi/cpu.asl
+++ b/src/cpu/amd/pi/00730F01/acpi/cpu.asl
@@ -1,65 +1,48 @@
 /* SPDX-License-Identifier: GPL-2.0-only */
 
-	/*
-	 * Processor Object
-	 *
-	 */
-	Scope (\_PR) {		/* define processor scope */
-		Processor(
-			P000,		/* name space name */
-			0,		/* Unique number for this processor */
-			0x810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
+/*
+ * Processor Object
+ *
+ */
+Scope (\_SB) {	/* define processor scope */
 
-		Processor(
-			P001,		/* name space name */
-			1,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P002,		/* name space name */
-			2,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P003,		/* name space name */
-			3,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P004,		/* name space name */
-			4,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P005,		/* name space name */
-			5,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P006,		/* name space name */
-			6,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-		Processor(
-			P007,		/* name space name */
-			7,		/* Unique number for this processor */
-			0x0810,		/* PBLK system I/O address !hardcoded! */
-			0x06		/* PBLKLEN for boot processor */
-			) {
-		}
-	} /* End _PR scope */
+	Device (P000) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 0)
+	}
+
+	Device (P001) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 1)
+	}
+
+	Device (P002) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 2)
+	}
+
+	Device (P003) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 3)
+	}
+
+	Device (P004) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 4)
+	}
+
+	Device (P005) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 5)
+	}
+
+	Device (P006) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 6)
+	}
+
+	Device (P007) {
+	Name(_HID, "ACPI0007")
+	Name(_UID, 7)
+	}
+} /* End _SB scope */

--- a/src/northbridge/amd/agesa/family14/state_machine.c
+++ b/src/northbridge/amd/agesa/family14/state_machine.c
@@ -94,6 +94,7 @@ void platform_BeforeInitMid(struct sysinfo *cb, AMD_MID_PARAMS *Mid)
 
 void platform_BeforeInitLate(struct sysinfo *cb, AMD_LATE_PARAMS *Late)
 {
+	Late->PlatformConfig.ProcessorScopeInSb = 1;
 }
 
 void platform_AfterInitLate(struct sysinfo *cb, AMD_LATE_PARAMS *Late)

--- a/src/northbridge/amd/pi/00730F01/state_machine.c
+++ b/src/northbridge/amd/pi/00730F01/state_machine.c
@@ -72,6 +72,8 @@ void platform_BeforeInitLate(struct sysinfo *cb, AMD_LATE_PARAMS *Late)
 	 * present AGESA_ERROR is returned, which confuses users. CDIT is not
 	 * written to the ACPI tables anyway. */
 	Late->PlatformConfig.UserOptionCdit = 0;
+
+	Late->PlatformConfig.ProcessorScopeInSb = 1;
 }
 
 void platform_AfterInitLate(struct sysinfo *cb, AMD_LATE_PARAMS *Late)


### PR DESCRIPTION
…or()'""

This reverts commit cd26f2a3b68593e2762d3b7617d59c0d03701dd4.

This enables compilation using newer versions of `coreboot-sdk`.

Signed-off-by: Michał Kopeć <michal.kopec@3mdeb.com>