### PR TITLE
Revert "mb/pcengines/apu2: Remove ACPI GPIO bindings"

### DIFF
--- a/src/mainboard/pcengines/apu2/acpi/buttons.asl
+++ b/src/mainboard/pcengines/apu2/acpi/buttons.asl
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the coreboot project.
+ *
+ * Based on the example of Mika Westerberg: https://lwn.net/Articles/612062/
+ *
+ * Copyright (C) 2015 Tobias Diedrich, Mika Westerberg
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+Scope (\_SB.PCI0)
+{
+	Device (BTNS)
+	{
+		Name (_HID, "PRP0001")
+
+		Name (_CRS, ResourceTemplate () {
+			GpioInt (Edge, ActiveLow, Shared, PullUp, ,
+				 "\\_SB.PCI0.GPIO") {
+			#if CONFIG(BOARD_PCENGINES_APU5)
+				9
+			#else
+				89
+			#endif
+			}
+		})
+
+		Name (_DSD, Package () {
+			ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+			Package () {
+				Package () {"compatible", "gpio-keys"},
+				Package () {"autorepeat", 1}
+			}
+		})
+
+		Device (BTN1)
+		{
+			Name (_HID, "PRP0001")
+			Name (_DSD, Package () {
+				ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+				Package () {
+					Package () {"linux,code", 257},
+					Package () {"linux,input-type", 1},
+					Package () {"debounce-interval", 100},
+					Package () {"label", "switch1"},
+					Package () {"interrupts", 7},
+					Package () {"gpios", Package ()
+							{^^BTNS, 0, 0, 1}}
+				}
+			})
+		}
+	}
+}

--- a/src/mainboard/pcengines/apu2/acpi/leds.asl
+++ b/src/mainboard/pcengines/apu2/acpi/leds.asl
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the coreboot project.
+ *
+ * Based on the example of Mika Westerberg: https://lwn.net/Articles/612062/
+ *
+ * Copyright (C) 2015 Tobias Diedrich, Mika Westerberg
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+Scope (\_SB.PCI0)
+{
+	Device (LEDS)
+	{
+		Name (_HID, "PRP0001")
+
+		Name (_CRS, ResourceTemplate () {
+			GpioIo (Exclusive, PullUp, 0, 0, IoRestrictionOutputOnly, "\\_SB.PCI0.GPIO", 0, ResourceConsumer) { 68, 69, 70 }
+		})
+
+		Name (_DSD, Package () {
+			ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+			Package () {
+				Package () {"compatible","gpio-leds"}
+			}
+		})
+
+		Device (LED1)
+		{
+			Name (_HID, "PRP0001")
+			Name (_DSD, Package () {
+				ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+				Package () {
+					Package () {"label", DEVICE_NAME:green:led1"},
+					Package () {"gpios", Package () {^^LEDS, 0, 0, 1 }},
+					Package () {"default-state", "on"}
+				}
+				
+			})
+		}
+
+		Device (LED2)
+		{
+			Name (_HID, "PRP0001")
+			Name (_DSD, Package () {
+				ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+				Package () {
+					Package () {"label", DEVICE_NAME:green:led2"},
+					Package () {"gpios", Package () {^^LEDS, 0, 1, 1 }},
+					Package () {"default-state", "off"}
+				}
+			})
+		}
+
+		Device (LED3)
+		{
+			Name (_HID, "PRP0001")
+			Name (_DSD, Package () {
+				ToUUID("daffd814-6eba-4d8c-8a91-bc9bbf4aa301"),
+				Package () {
+					Package () {"label", DEVICE_NAME:green:led3"},
+					Package () {"gpios", Package () {^^LEDS, 0, 2, 1 }},
+					Package () {"linux,default-trigger", "heartbeat"}
+				}
+			})
+		}
+	}
+}

--- a/src/mainboard/pcengines/apu2/dsdt.asl
+++ b/src/mainboard/pcengines/apu2/dsdt.asl
@@ -75,5 +75,9 @@ DefinitionBlock (
 
 	/* Super IO devices (COM ports) */
 	#include "acpi/superio.asl"
+
+	/* GPIO buttons and leds */
+	#include "acpi/buttons.asl"
+	#include "acpi/leds.asl"
 }
 /* End of ASL file */


### PR DESCRIPTION
This restores the ACPI GPIO bindings on apu2-6 devices. This restores the previous method of accessing the GPIOs used and should be used instead of the Linux `pcengines-apuv2` driver, which as of today in the mainline kernel, does not correctly support the S1 button.

See comment https://github.com/pcengines/apu2-documentation/issues/204#issuecomment-957314690

This reverts commit bca61d7cc6986d1b1158a45b3513b8af30edf77c.