### PR TITLE
mainboard/pcengines: fix sign-of-life coreboot build date

### DIFF
--- a/src/mainboard/pcengines/apu1/romstage.c
+++ b/src/mainboard/pcengines/apu1/romstage.c
@@ -60,8 +60,8 @@ static void print_sign_of_life()
 {
 	char tmp[9];
 	strncpy(tmp,   coreboot_dmi_date+6, 4);
-	strncpy(tmp+4, coreboot_dmi_date+3, 2);
-	strncpy(tmp+6, coreboot_dmi_date,   2);
+	strncpy(tmp+4, coreboot_dmi_date,   2);
+	strncpy(tmp+6, coreboot_dmi_date+3, 2);
 	tmp[8] = '\0';
 	printk(BIOS_ALERT, CONFIG_MAINBOARD_VENDOR " "
 	                   CONFIG_MAINBOARD_PART_NUMBER "\n");

--- a/src/mainboard/pcengines/apu2/romstage.c
+++ b/src/mainboard/pcengines/apu2/romstage.c
@@ -101,8 +101,8 @@ static void print_sign_of_life()
 {
 	char tmp[9];
 	strncpy(tmp,   coreboot_dmi_date+6, 4);
-	strncpy(tmp+4, coreboot_dmi_date+3, 2);
-	strncpy(tmp+6, coreboot_dmi_date,   2);
+	strncpy(tmp+4, coreboot_dmi_date,   2);
+	strncpy(tmp+6, coreboot_dmi_date+3, 2);
 	tmp[8] = '\0';
 	printk(BIOS_ALERT, CONFIG_MAINBOARD_VENDOR " "
 	                   CONFIG_MAINBOARD_PART_NUMBER "\n");


### PR DESCRIPTION
The coreboot build date shown by `print_sign_of_life` at early boot was incorrectly presented in `yyyyddmm` format, when it should have been `yyyymmdd`.

For example, the [current version, 4.16.0.4](https://pcengines.github.io/#mr-59), was built on 2022-05-25 and released on 2022-05-26. It boots with the following sign-of-life message:

```
PC Engines apu2
coreboot build 20222505
BIOS version v4.16.0.4
```

`yyyyddmm` is not a date format that any ordinary person would expect or understand. It presents as a standard `yyyymmdd` date seemingly referring to the 5th day of the 25th month of 2022, which of course is incorrect. The string should be presented as `coreboot build 20220525`, in proper `yyyymmdd` format.

There’s a bit of history to this string, and I wanted to make sure that this wasn’t actually intentional, so I did all of the code archaeology to confirm that `yyyyddmm` was indeed unintentional and should be fixed to the expected `yyyymmdd`.

Legacy History
--

| commit | commit date | pr | release | release date | sign-of-life format | SMBIOS/DMI format | notes |
| - | - | - | - | - | - | - | - |
| 88a4f96110fbd3f55ee727bd01f53875f1c6c398 | 2016-03-04 | | 4.0.1 | | `yyyymmdd` | `mm/dd/yyyy` | [romstage.c](https://github.com/pcengines/coreboot/blame/v4.0.1/src/mainboard/pcengines/apu2/romstage.c#L182), [version.c](https://github.com/pcengines/coreboot/blame/v4.0.1/src/lib/version.c#L45), [smbios.c](https://github.com/pcengines/coreboot/blame/v4.0.1/src/arch/x86/boot/smbios.c#L141), [Makefile.inc](https://github.com/pcengines/coreboot/blame/v4.0.1/Makefile.inc#L330)
| ca048fd133174fe001e1f494f1d83a8cda9db3f6 | 2017-01-02 | | 4.0.3 | | `yyyymmdd` | `mm/dd/yyyy` | [mainboard.c](https://github.com/pcengines/coreboot/blame/v4.0.3/src/mainboard/pcengines/apu2/mainboard.c#L70) (duplicates romstage.c) |
| 8d1dbd46e9f9e3e61749dd90fdd68eac2f3c2ec7 | 2017-09-29 | | 4.0.13 | 2017-09-29 | `yyyymmdd` | `yyyymmdd` | removes duplicate from mainboard.c, breaks SMBIOS/DMI date |
| a27c678a7fd748af3c5f3a20725b9f0896f4f37c | 2018-10-22 | https://github.com/pcengines/coreboot/pull/213 | | | `mm/dd/yyyy` | `mm/dd/yyyy` | fixes SMBIOS/DMI date, breaks sign-of-life date |
| 904102b4fec71ef66f7e6e43c0861127561e0b01 | 2018-10-22 | https://github.com/pcengines/coreboot/pull/213 | | | `yyyymmdd` | `mm/dd/yyyy` | fixes sign-of-life date |
| 7de39fa06096984bce6abdb67edbdfb25ee5cf66 | 2018-10-23 | https://github.com/pcengines/coreboot/pull/213 | 4.0.21 | 2018-11-08 | `yyyyddmm` | `mm/dd/yyyy` | breaks sign-of-life date |

Mainline History
--

| commit | commit date | pr | release | release date | sign-of-life format | SMBIOS/DMI format | notes |
| - | - | - | - | - | - | - | - |
| 05e02e457dadb75c6081471b9f5b06018ac47fe1 | 2017-01-23 | | | | POSIX locale | `mm/dd/yyyy` | sign-of-life broken; [mainboard.c](https://github.com/pcengines/coreboot/blob/05e02e457dadb75c6081471b9f5b06018ac47fe1/src/mainboard/pcengines/apu2/mainboard.c#L185), [version.c](https://github.com/pcengines/coreboot/blob/05e02e457dadb75c6081471b9f5b06018ac47fe1/src/lib/version.c#L35), [smbios.c](https://github.com/pcengines/coreboot/blob/05e02e457dadb75c6081471b9f5b06018ac47fe1/src/arch/x86/smbios.c#L284), [genbuild_h.sh](https://github.com/pcengines/coreboot/blob/05e02e457dadb75c6081471b9f5b06018ac47fe1/util/genbuild_h/genbuild_h.sh#L63) |
| 6333e2ced9e1f41c131f38c028b84ce693322da3 | 2017-02-24 | | | | `mm/dd/yyyy` | `mm/dd/yyyy` | breaks sign-of-life date differently |
| 59b86e139b4ab276676bc234533730052e2f10fa | 2017-07-18 | | 4.6.1 | 2017-08-30 | `mm/dd/yyyy` | `mm/dd/yyyy` | sign-of-life moved to romstage.c |
| 2abb157e1011115c7a2302a7472ca09e0aef787d | 2017-10-26 | | | | `mm/dd/yyyy` | `mm/dd/yyyy` | |
| ba77b6cbbece535dc5ae2aa6114bd8525084191b | 2017-09-25 | | 4.6.2 | 2017-09-29 | `yyyymmdd` | `yyyymmdd` | fixes sign-of-life date, breaks SMBIOS/DMI date |
| 87c0ee4e3cf35356529b19701fc14ef3dc040bf3 | 2018-07-17 | | | | `mm/dd/yyyy` | `mm/dd/yyyy` | reverts ba77b6cbbece535dc5ae2aa6114bd8525084191b, breaks sign-of-life date, fixes SMBIOS/DMI date |
| 10fa08fc94f5433a55d75a65e1c70a44992587de | 2018-07-18 | | | | `yyyyddmm` | `yyyyddmm` | breaks sign-of-life date differently, breaks SMBIOS/DMI date |
| e7b562be79d4caaac1daa6ce3cca9942ae72d20f | 2018-07-24 | | 4.8.0.3 | 2018-08-07 | `yyyyddmm` | `yyyyddmm` | |
| a3249e88cc00759feea63e92522763746e3e4ec9 | 2018-09-18 | https://github.com/pcengines/coreboot/pull/197 | 4.8.0.5 | 2018-10-04 | `yyyyddmm` | `mm/dd/yyyy` | fixes SMBIOS/DMI date |
| 2a07f6af3d1e7180714ffc4f25f9b80352722738 | 2020-11-17 | | | | `yyyyddmm` | `mm/dd/yyyy` | moves sign-of-life to bootblock.c |
| d120418f871d579fcf92ce79ef08f953fd326721 | 2020-11-25 | | 4.13.0.4 | 2021-02-26 | ` yyyyddmm` | `mm/dd/yyyy` | reverts 2a07f6af3d1e7180714ffc4f25f9b80352722738 |

Discussion
--

Both the sign-of-life date format and SMBIOS/DMI date format were variously correct and broken throughout time on both legacy and mainline branches, and were correct until late 2017, when the formats started changing during the [DMI date fiasco](https://github.com/pcengines/apu2-documentation/issues/117). The current `yyyyddmm` format can be traced to mainline 10fa08fc94f5433a55d75a65e1c70a44992587de which attempted to fix both the sign-of-life date and the SMBIOS/DMI date, but failed on both counts. The SMBIOS/DMI date was subsequently fixed in https://github.com/pcengines/coreboot/pull/197 without any real discussion of the sign-of-life date.

Shortly thereafter, https://github.com/pcengines/coreboot/pull/213 fixed the SMBIOS/DMI date on the legacy branch, while simultaneously breaking the sign-of-life date. That pull request has some discussion of the unusual format, starting at https://github.com/pcengines/coreboot/pull/213#issuecomment-432162036. Unfortunately, the discussion was resolved incorrectly at https://github.com/pcengines/coreboot/pull/213#issuecomment-432167732 by stating that `yyyyddmm` was intentionally chosen to match what was then current on the mainline branch. This occurred just months after the mainline branch had acquired the bug in 10fa08fc94f5433a55d75a65e1c70a44992587de, so while the legacy branch was being synced with the then-current mainline behavior, it was actually mimicking a recently introduced bug. https://github.com/pcengines/coreboot/pull/213#issuecomment-432174663 also claims to have corroborated with an APU2 ROM binary purportedly dated 2016-09-12 and identifying itself in its sign-of-life as 20161209. I haven’t found a binary bearing this date, but I did find:

 - [apu2 release 20160304](https://github.com/pcengines/coreboot/raw/v4.0.1/src/mainboard/pcengines/apu2/coreboot.rom) (from 88a4f96110fbd3f55ee727bd01f53875f1c6c398) built 2016-03-04, identifying in sign-of-life as `coreboot build 20160304` (`yyyymmdd`)
 - [apu2 4.0.7](https://www.pcengines.ch/file/apu2_v4.0.7.rom.zip) built 2017-02-28, identifying in sign-of-life as `coreboot build 20170228` (`yyyymmdd`)
 - [apu2 4.0.9](https://3mdeb.com/open-source-firmware/pcengines/apu2/apu2_v4.0.9.zip) released 2017-05-30, identifying in sign-of-life as `coreboot build 20170531` (`yyyymmdd`)

Having found three apu2 firmware versions from both before and after the purported 2016-09-12 (or is it 2016-12-09?) firmware that adhere properly to the `yyyymmdd` format, I question the claim in https://github.com/pcengines/coreboot/pull/213#issuecomment-432174663 that `yyyyddmm` was ever valid, and that employing this format was in fact maintaining the status quo.

This analysis clarifies that `yyyyddmm` is an error, and it should be corrected to `yyyymmdd` which is the proper historical form dating to the beginning of the visible legacy branch history in early 2016, as well as the sensible form for this date.